### PR TITLE
Add retry logic to http requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,3 +119,24 @@ During this entire process the Relays should be sending writes to both servers f
 ## Sharding
 
 It's possible to add another layer on top of this kind of setup to shard data. Depending on your needs you could shard on the measurement name or a specific tag like `customer_id`. The sharding layer would have to service both queries and writes.
+
+## Buffering
+
+The relay can be configured to buffer failed requests.
+The intent of this logic is reduce the number of failures during short outages or periodic network issues.
+> This retry logic is **NOT** sufficient for for long periods of downtime as all data is buffered in RAM
+
+Buffering has two configuration options:
+
+* BufferSize -- the maximum number of requests to buffer per backend.
+* MaxDelayInterval -- the max delay between retry attempts per backend.
+    The initial retry interval is 500ms and is doubled after every failure.
+
+If the buffer is full then requests are dropped and an error is logged.
+If a requests makes it into the buffer it is retried until success.
+
+Retries are serialized to a single backend.
+Meaning that buffered requests are attempted one at a time.
+If buffered requests succeed then there is no delay between subsequent attempts.
+
+

--- a/relay/config.go
+++ b/relay/config.go
@@ -32,6 +32,13 @@ type HTTPOutputConfig struct {
 	// Timeout sets a per-backend timeout for write requests. (Default 10s)
 	// The format used is the same seen in time.ParseDuration
 	Timeout string `toml:"timeout"`
+
+	// Buffer failed writes up to maximum count.
+	BufferSize int `toml:"buffer-size"`
+
+	// Maximum delay between retry attempts.
+	// The format used is the same seen in time.ParseDuration (Default 10s)
+	MaxDelayInterval string `toml:"max-delay-interval"`
 }
 
 type UDPConfig struct {

--- a/relay/http.go
+++ b/relay/http.go
@@ -301,12 +301,7 @@ func (b *httpBackend) post(buf []byte, query string) (response *http.Response, e
 	req.Header.Set("Content-Length", fmt.Sprint(len(buf)))
 
 	// Check if we are in buffering mode
-	var buffering int32
-	if b.retryBuffer != nil {
-		// load current buffering state
-		buffering = atomic.LoadInt32(&b.buffering)
-	}
-	if buffering == 0 {
+	if atomic.LoadInt32(&b.buffering) == 0 {
 		// Do action once
 		response, err = b.client.Do(req)
 		if err == nil {

--- a/relay/http.go
+++ b/relay/http.go
@@ -28,10 +28,10 @@ type HTTP struct {
 }
 
 const (
-	DefaultHTTPTimeout      = time.Second * 10
-	DefaultMaxDelayInterval = time.Second * 10
-	DefaultInitialInterval  = time.Millisecond * 500
-	DefaultMultiplier       = time.Duration(2)
+	DefaultHTTPTimeout      = 10 * time.Second
+	DefaultMaxDelayInterval = 10 * time.Second
+	DefaultInitialInterval  = 500 * time.Millisecond
+	DefaultMultiplier       = 2
 )
 
 func NewHTTP(cfg HTTPConfig) (Relay, error) {

--- a/relay/retry.go
+++ b/relay/retry.go
@@ -1,0 +1,83 @@
+package relay
+
+import (
+	"errors"
+	"sync"
+	"time"
+)
+
+type Operation func() error
+
+// Buffers and retries operations, if the buffer is full operations are dropped.
+// Only tries one operation at a time, the next operation is not attempted
+// until success or timeout of the previous operation.
+// There is no delay between attempts of different operations.
+type retryBuffer struct {
+	buf chan retryOperation
+
+	initialInterval time.Duration
+	multiplier      time.Duration
+	maxInterval     time.Duration
+
+	wg sync.WaitGroup
+}
+
+func newRetryBuffer(size int, initial, multiplier, max time.Duration) *retryBuffer {
+	r := &retryBuffer{
+		buf:             make(chan retryOperation, size),
+		initialInterval: initial,
+		multiplier:      multiplier,
+		maxInterval:     max,
+	}
+	r.wg.Add(1)
+	go r.run()
+	return r
+}
+
+// Stops the retryBuffer.
+// Subsequent calls to Rety will panic.
+// Actions currently in the buffer will still be tried.
+// Blocks until buffer is empty.
+func (r *retryBuffer) Stop() {
+	close(r.buf)
+	r.wg.Wait()
+}
+
+type retryOperation struct {
+	op   Operation
+	errC chan error
+}
+
+// Retry an operation, it is expected that one attempt has already
+// been made as this sleeps before trying again.
+func (r *retryBuffer) Retry(op Operation) error {
+	retry := retryOperation{
+		op:   op,
+		errC: make(chan error),
+	}
+
+	select {
+	case r.buf <- retry:
+		return <-retry.errC
+	default:
+		return errors.New("buffer full cannot retry")
+	}
+}
+
+func (r *retryBuffer) run() {
+	defer r.wg.Done()
+	for retry := range r.buf {
+		interval := r.initialInterval
+		for {
+			if err := retry.op(); err == nil {
+				retry.errC <- nil
+				break
+			}
+			interval *= r.multiplier
+			if interval > r.maxInterval {
+				interval = r.maxInterval
+			}
+			time.Sleep(interval)
+		}
+	}
+}

--- a/sample_buffered.toml
+++ b/sample_buffered.toml
@@ -1,0 +1,18 @@
+
+
+[[http]]
+name = "example-http"
+bind-addr = "127.0.0.1:9096"
+output = [
+    { name="local1", location = "http://127.0.0.1:8086/write", buffer-size = 1000, max-delay-interval = "15s" },
+    { name="local2", location = "http://127.0.0.1:7086/write", buffer-size = 1000, max-delay-interval = "15s" },
+]
+
+[[udp]]
+name = "example-udp"
+bind-addr = "127.0.0.1:9096"
+read-buffer = 0 # default
+output = [
+    { name="local1", location="127.0.0.1:8089", mtu=512 },
+    { name="local2", location="127.0.0.1:7089", mtu=1024 },
+]


### PR DESCRIPTION
This add retry logic to the HTTP backends. Obviously it doesn't make sense to add retry logic to the UDP backend. The intent of this logic is reduce the number of failures during short outages or periodic network issues. **This retry logic is not sufficient for for long periods of downtime as all data is buffered in RAM **

Config options
* BufferSize -- global maximum number of writes operations to buffer, each backend output gets an equal portion of this size
* MaxRetryTime -- maximum time a write operation will be tried. If more than this time elapsed it is dropped

With these two config options is should be easy to reason about your fault tolerance properties. For example if MaxRetryTime is 1m than a backend server cannot be down more than a minute or it will be guaranteed to be out of sync. BufferSize should to be large enough to buffer all write operations for MaxRetyTime, empirically you should be able to measure RAM usage as needed.

Each backend has its own buffer and retries are serialized to each backend. This should prevent stampeeding of requests once a backend server recovers from an outage.

TODO:
- [x] Update README about how to configure and use the retry logic

NOTE: I also implemented the HTTP timeout since it was a configuration option but did not work. (I ran unto that bug during testing)

~~NOTE: This PR adds one new dependency  on https://github.com/cenkalti/backoff
I thought about copy/pasting the needed bits but that mean nearly all of the repo, so I decided importing was better than copy/paste here. Its a simple well written package. I could be convinced otherwise if someone else feels strongly.~~ Dep has been removed
