### PR TITLE
Support skip-tls-verification for https output

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ output = [
     # name: name of the backend, used for display purposes only.
     # location: full URL of the /write endpoint of the backend
     # timeout: Go-parseable time duration. Fail writes if incomplete in this time.
+    # skip-tls-verification: skip verification for HTTPS location. WARNING: it's insecure. Don't use in production.
     { name="local1", location="http://127.0.0.1:8086/write", timeout="10s" },
     { name="local2", location="http://127.0.0.1:7086/write", timeout="10s" },
 ]

--- a/relay/config.go
+++ b/relay/config.go
@@ -39,6 +39,10 @@ type HTTPOutputConfig struct {
 	// Maximum delay between retry attempts.
 	// The format used is the same seen in time.ParseDuration (Default 10s)
 	MaxDelayInterval string `toml:"max-delay-interval"`
+
+	// Skip TLS verification in order to use self signed certificate.
+	// WARNING: It's insecure. Use it only for developing and don't use in production.
+	SkipTLSVerification bool `toml:"skip-tls-verification"`
 }
 
 type UDPConfig struct {

--- a/relay/http.go
+++ b/relay/http.go
@@ -71,7 +71,7 @@ func NewHTTP(cfg HTTPConfig) (Relay, error) {
 		}
 
 		// Configure custom transport for http.Client
-		// Use for support skip-tls-verification option
+		// Used for support skip-tls-verification option
 		transport := &http.Transport{
 			TLSClientConfig: &tls.Config{
 				InsecureSkipVerify: b.SkipTLSVerification,

--- a/relay/http.go
+++ b/relay/http.go
@@ -69,15 +69,13 @@ func NewHTTP(cfg HTTPConfig) (Relay, error) {
 			}
 			rb = newRetryBuffer(b.BufferSize, DefaultInitialInterval, DefaultMultiplier, max)
 		}
-		var transport http.RoundTripper // nil - will be use DefaultTransport
 
-		if b.SkipTLSVerification {
-			// will be use Custom Transport instead of Default
-			transport = &http.Transport{
-				TLSClientConfig: &tls.Config{
-					InsecureSkipVerify: b.SkipTLSVerification,
-				},
-			}
+		// Configure custom transport for http.Client
+		// Use for support skip-tls-verification option
+		transport := &http.Transport{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: b.SkipTLSVerification,
+			},
 		}
 
 		h.backends = append(h.backends, &httpBackend{


### PR DESCRIPTION
Hi.

On staging we use self signed certificates for InfluxDB and we need skip TLS certificate verification. Could you check pull-request and decide apply changes or not. I understand it's insecure and need be careful with such options.

Thanks.