### PR TITLE
influxdb-relay: add possibility to specify default retention policy

### DIFF
--- a/kapacitor.toml
+++ b/kapacitor.toml
@@ -16,9 +16,9 @@
 [[http]]
 name = "kapacitor-http"
 bind-addr = "0.0.0.0:9096"
+default-retention-policy = "default"
 output = [
     { name="influxdb1", location = "http://influxdb1:8086/write" },
     { name="influxdb2", location = "http://influxdb2:8086/write" },
     { name="kapacitor1", location = "http://kapacitor1:9092/write" },
 ]
-

--- a/relay/config.go
+++ b/relay/config.go
@@ -21,6 +21,9 @@ type HTTPConfig struct {
 	// Set certificate in order to handle HTTPS requests
 	SSLCombinedPem string `toml:"ssl-combined-pem"`
 
+	// Default retention policy to set for forwarded requests
+	DefaultRetentionPolicy string `toml:"default-retention-policy"`
+
 	// Outputs is a list of backed servers where writes will be forwarded
 	Outputs []HTTPOutputConfig `toml:"output"`
 }


### PR DESCRIPTION
Improvement idea to allow forwarding data points to Kapacitor.

Add possibility to configure default retention policy for forwarded
metrics that don't have it set in the write request. This is required
in order to get telegraf metrics properly working when forwarded to
Kapacitor as Kapacitor always requires retention policy for the
written data points.