### PR TITLE
Provide satisfactory response to {GET, HEAD} /ping

### DIFF
--- a/relay/http.go
+++ b/relay/http.go
@@ -112,6 +112,13 @@ func (h *HTTP) Stop() error {
 
 func (h *HTTP) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	start := time.Now()
+
+	if r.URL.Path == "/ping" && (r.Method == "GET" || r.Method == "HEAD") {
+			w.Header().Add("X-InfluxDB-Version", "relay")
+			w.WriteHeader(http.StatusNoContent)
+			return
+	}
+
 	if r.URL.Path != "/write" {
 		jsonError(w, http.StatusNotFound, "invalid write endpoint")
 		return


### PR DESCRIPTION
Proposition to fix #24 

Clients that write to Influx might want to use the `/ping` on their startup to check the backend status.

Here relay would provide some simple compliance by responding with the same response signature to
the ping but without contacting the InfluxDB backends.
