### PR TITLE
fix panic: runtime error: invalid memory address or nil pointer deref…

### DIFF
--- a/relay/retry.go
+++ b/relay/retry.go
@@ -195,6 +195,6 @@ func (l *bufferList) add(buf []byte, query string, auth string) (*batch, error) 
 		b.bufs = append(b.bufs, buf)
 	}
 
-	l.cond.L.Unlock()
+	defer l.cond.L.Unlock()
 	return *cur, nil
 }


### PR DESCRIPTION
Unlock before return, then the pop method may modify the value of cur. 