### PR TITLE
Feature/ping response code

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ name = "example-http"
 # TCP address to bind to, for HTTP server.
 bind-addr = "127.0.0.1:9096"
 
+# Ping response code, default is 204
+default-ping-response = 200
+
 # Enable HTTPS requests.
 ssl-combined-pem = "/etc/ssl/influxdb-relay.pem"
 

--- a/relay/config.go
+++ b/relay/config.go
@@ -24,6 +24,9 @@ type HTTPConfig struct {
 	// Default retention policy to set for forwarded requests
 	DefaultRetentionPolicy string `toml:"default-retention-policy"`
 
+	// Default ping response
+	DefaultPingResponse int `toml:"default-ping-response"`
+
 	// Outputs is a list of backed servers where writes will be forwarded
 	Outputs []HTTPOutputConfig `toml:"output"`
 }

--- a/relay/http.go
+++ b/relay/http.go
@@ -122,9 +122,9 @@ func (h *HTTP) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if r.URL.Path == "/ping" && (r.Method == "GET" || r.Method == "HEAD") {
-			w.Header().Add("X-InfluxDB-Version", "relay")
-			w.WriteHeader(pingStatusResponse)
-			return
+		w.Header().Add("X-InfluxDB-Version", "relay")
+		w.WriteHeader(pingStatusResponse)
+		return
 	}
 
 	if r.URL.Path != "/write" {

--- a/sample.toml
+++ b/sample.toml
@@ -3,6 +3,7 @@
 [[http]]
 name = "example-http"
 bind-addr = "127.0.0.1:9096"
+default-ping-response = 204
 output = [
     { name="local1", location = "http://127.0.0.1:8086/write" },
     { name="local2", location = "http://127.0.0.1:7086/write" },


### PR DESCRIPTION
Hey guys,

We had a problem regarding the hardcoded `204 No Content` of `/ping` response code.
Indeed, Google Cloud Plateform `http health-checks` only accept `200 OK`.
With this PR, you'll be able to control what response code of `/ping` you want/need to have, from the config file, using `default-ping-response`.

Thank you guys for this great tool!