### PR TITLE
Add /status endpoint

### DIFF
--- a/relay/http.go
+++ b/relay/http.go
@@ -114,9 +114,9 @@ func (h *HTTP) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	start := time.Now()
 
 	if r.URL.Path == "/ping" && (r.Method == "GET" || r.Method == "HEAD") {
-			w.Header().Add("X-InfluxDB-Version", "relay")
-			w.WriteHeader(http.StatusNoContent)
-			return
+		w.Header().Add("X-InfluxDB-Version", "relay")
+		w.WriteHeader(http.StatusNoContent)
+		return
 	}
 
 	if r.URL.Path != "/write" {

--- a/relay/http.go
+++ b/relay/http.go
@@ -293,6 +293,7 @@ func jsonResponse(w http.ResponseWriter, code int, message string) {
 
 type poster interface {
 	post([]byte, string, string) (*responseData, error)
+	getStats() map[string]string
 }
 
 type simplePoster struct {
@@ -316,6 +317,12 @@ func newSimplePoster(location string, timeout time.Duration, skipTLSVerification
 		},
 		location: location,
 	}
+}
+
+func (s *simplePoster) getStats() map[string]string {
+	v := make(map[string]string)
+	v["location"] = s.location
+	return v
 }
 
 func (b *simplePoster) post(buf []byte, query string, auth string) (*responseData, error) {

--- a/relay/http.go
+++ b/relay/http.go
@@ -120,6 +120,25 @@ func (h *HTTP) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if r.URL.Path == "/status" && (r.Method == "GET" || r.Method == "HEAD") {
+		st := make(map[string]map[string]string)
+
+		for _, b := range h.backends {
+			st[b.name] = b.poster.getStats()
+		}
+
+		j, err := json.Marshal(st)
+
+		if err != nil {
+			log.Printf("error: %s", err)
+			jsonResponse(w, http.StatusInternalServerError, "json marshalling failed")
+			return
+		}
+
+		jsonResponse(w, http.StatusOK, fmt.Sprintf("\"status\": %s", string(j)))
+		return
+	}
+
 	if r.URL.Path != "/write" {
 		jsonResponse(w, http.StatusNotFound, "invalid write endpoint")
 		return

--- a/relay/retry.go
+++ b/relay/retry.go
@@ -2,6 +2,7 @@ package relay
 
 import (
 	"bytes"
+	"strconv"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -45,6 +46,15 @@ func newRetryBuffer(size, batch int, max time.Duration, p poster) *retryBuffer {
 	}
 	go r.run()
 	return r
+}
+
+func (r *retryBuffer) getStats() map[string]string {
+	stats := make(map[string]string)
+	stats["buffering"] = strconv.FormatInt(int64(r.buffering), 10)
+	for k, v := range r.list.getStats() {
+		stats[k] = v
+	}
+	return stats
 }
 
 func (r *retryBuffer) post(buf []byte, query string, auth string) (*responseData, error) {
@@ -136,6 +146,13 @@ func newBufferList(maxSize, maxBatch int) *bufferList {
 		maxSize:  maxSize,
 		maxBatch: maxBatch,
 	}
+}
+
+func (l *bufferList) getStats() map[string]string {
+	stats := make(map[string]string)
+	stats["size"] = strconv.FormatInt(int64(l.size), 10)
+	stats["maxSize"] = strconv.FormatInt(int64(l.maxSize), 10)
+	return stats
 }
 
 // pop will remove and return the first element of the list, blocking if necessary


### PR DESCRIPTION
This adds new /status endpoint which should report current status of relay, i.e. list of endpoints, amount of buffer used and whether the buffering is active or not.

That info is crucial for implementing proper monitoring of relay, predicting acceptable downtime (as mentioned in #49) and scaling.

Side effect of this patch is refactor of jsonError function to a more general jsonResponse. We've been using a variation of this patch for a couple of months in production with no noticeable side-effects.

Example output (using sample_buffered.toml) with local1 instance being available and local2 being unreachable:
```
$ curl -s localhost:9096/status |python -m json.tool                                                                                                                                                                          
{
    "status": {
        "local1": {
            "buffering": "0",
            "maxSize": "104857600",
            "size": "0"
        },
        "local2": {
            "buffering": "1",
            "maxSize": "104857600",
            "size": "75"
        }
    }
}
```
